### PR TITLE
Match TS progress reporting to PS format

### DIFF
--- a/tivo_decoder_ps.cxx
+++ b/tivo_decoder_ps.cxx
@@ -189,28 +189,28 @@ int TiVoDecoderPS::process_frame(uint8_t code, hoff_t packet_start)
                                     int block_no = 0;
                                     int crypted  = 0;
 
-                                    VERBOSE("\n\n---Turing : Key\n");
-                                    if ( IS_VERBOSE )
+                                    VVERBOSE("\n\n---Turing : Key\n");
+                                    if ( IS_VVERBOSE )
                                         hexbulk( (uint8_t *)&bytes[off], 16 );
-                                    VERBOSE("---Turing : header : block %d crypted 0x%08x\n", block_no, crypted );
+                                    VVERBOSE("---Turing : header : block %d crypted 0x%08x\n", block_no, crypted );
 
                                     if (do_header (&bytes[off], &block_no, NULL, &crypted, NULL, NULL))
                                     {
                                         VERBOSE( "do_header did not return 0!\n");
                                     }
 
-                                    VERBOSE("BBB : code 0x%02x, blockno %d, crypted 0x%08x\n", code, block_no, crypted );
+                                    VVERBOSE("BBB : code 0x%02x, blockno %d, crypted 0x%08x\n", code, block_no, crypted );
                                     VERBOSE("%zu : stream_no: %x, block_no: %d\n", (size_t)packet_start, code, block_no);
-                                    VERBOSE("---Turing : prepare : code 0x%02x block_no %d\n", code, block_no );
+                                    VVERBOSE("---Turing : prepare : code 0x%02x block_no %d\n", code, block_no );
 
                                     pTuring->prepare_frame(code, block_no);
 
-                                    VERBOSE("CCC : code 0x%02x, blockno %d, crypted 0x%08x\n", code, block_no, crypted );
-                                    VERBOSE("---Turing : decrypt : crypted 0x%08x len %d\n", crypted, 4 );
+                                    VVERBOSE("CCC : code 0x%02x, blockno %d, crypted 0x%08x\n", code, block_no, crypted );
+                                    VVERBOSE("---Turing : decrypt : crypted 0x%08x len %d\n", crypted, 4 );
 
                                     pTuring->decrypt_buffer((uint8_t *)&crypted, 4);
 
-                                    VERBOSE("DDD : code 0x%02x, blockno %d, crypted 0x%08x\n", code, block_no, crypted );
+                                    VVERBOSE("DDD : code 0x%02x, blockno %d, crypted 0x%08x\n", code, block_no, crypted );
 
                                 }
 
@@ -264,7 +264,7 @@ int TiVoDecoderPS::process_frame(uint8_t code, hoff_t packet_start)
 
                     if (scramble == 3)
                     {
-                        VERBOSE("---Turing : decrypt : size %d\n", (int)packet_size );
+                        VVERBOSE("---Turing : decrypt : size %d\n", (int)packet_size );
 
                         pTuring->decrypt_buffer(packet_ptr, packet_size);
 

--- a/tivo_decoder_ts.cxx
+++ b/tivo_decoder_ts.cxx
@@ -473,7 +473,7 @@ bool TiVoDecoderTS::process()
         pid      = 0;
 
         pktCounter++;
-        VERBOSE("Packet : %d\n", pktCounter);
+        VVERBOSE("Packet : %d\n", pktCounter);
 
         TiVoDecoderTsPacket *pPkt = new TiVoDecoderTsPacket;
         if (!pPkt)
@@ -519,9 +519,9 @@ bool TiVoDecoderTS::process()
             return 10;
         }
         
-        if (IS_VERBOSE)
+        if (IS_VVERBOSE)
         {
-            VERBOSE("=============== Packet : %d ===============\n",
+            VVERBOSE("=============== Packet : %d ===============\n",
                     pPkt->packetId);
             pPkt->dump();
         }

--- a/tivo_decoder_ts_pkt.cxx
+++ b/tivo_decoder_ts_pkt.cxx
@@ -386,6 +386,7 @@ bool TiVoDecoderTsStream::decrypt(uint8_t *pBuffer, uint16_t bufferLen)
     if (IS_VVVERBOSE)
         std::fprintf(stderr, "BBB : stream_id 0x%02x, blockno %d, crypted 0x%08x\n",
                      stream_id, turing_stuff.block_no, turing_stuff.crypted);
+    VERBOSE("%lld : stream_id: %x, block_no: %d\n", pParent->pFileIn->tell(), stream_id, turing_stuff.block_no);
 
     pParent->pTuring->prepare_frame(stream_id, turing_stuff.block_no);
 

--- a/tivo_decoder_ts_stream.cxx
+++ b/tivo_decoder_ts_stream.cxx
@@ -59,7 +59,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
 
     if ((true == pPkt->getPayloadStartIndicator()) || (0 != packets.size()))
     {
-        VERBOSE("Add PktID %d from PID 0x%04x to packet list : payloadStart "
+        VVERBOSE("Add PktID %d from PID 0x%04x to packet list : payloadStart "
                 "%d listCount %zu\n", pPkt->packetId, stream_pid, 
                 pPkt->getPayloadStartIndicator(), packets.size());
 
@@ -71,7 +71,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
         for (pkt_iter = packets.begin(); pkt_iter != packets.end(); pkt_iter++)
         {
             pPkt2 = *pkt_iter;
-            VERBOSE("DEQUE : PktID %d from PID 0x%04x\n", pPkt2->packetId,
+            VVERBOSE("DEQUE : PktID %d from PID 0x%04x\n", pPkt2->packetId,
                     stream_pid);
 
             std::memcpy(&pesDecodeBuffer[pesDecodeBufferLen],
@@ -114,7 +114,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
         // Do the PES headers end in this packet ?
         if (pesHeaderLength < pesDecodeBufferLen)
         {
-            VERBOSE("FLUSH BUFFERS\n");
+            VVERBOSE("FLUSH BUFFERS\n");
             flushBuffers = true;
 
             // For each packet, set the end point for PES headers in 
@@ -198,7 +198,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
     }
     else
     {
-        VERBOSE("Push Back : PayloadStartIndicator %d, packets.size() %zu \n", 
+        VVERBOSE("Push Back : PayloadStartIndicator %d, packets.size() %zu \n", 
             pPkt->getPayloadStartIndicator(), packets.size());
         flushBuffers = true;
         packets.push_back(pPkt);
@@ -206,7 +206,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
     
     if (true == flushBuffers)
     {        
-        VERBOSE("Flush packets for write\n");
+        VVERBOSE("Flush packets for write\n");
         
         // Loop through each buffered packet.
         // If it is encrypted, perform decryption and then write it out.
@@ -215,7 +215,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
         {
             pPkt2 = *pkt_iter;
 
-            VERBOSE("Flushing packet %d\n", pPkt2->packetId);
+            VVERBOSE("Flushing packet %d\n", pPkt2->packetId);
 
             if (true == pPkt2->getScramblingControl())
             {
@@ -224,7 +224,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
                     pPkt2->pesHdrOffset;
                 uint8_t decryptLen = TS_FRAME_SIZE - decryptOffset;
 
-                VERBOSE("Decrypting PktID %d from stream 0x%04x : "
+                VVERBOSE("Decrypting PktID %d from stream 0x%04x : "
                         "decrypt offset %d len %d\n", pPkt2->packetId, 
                         stream_pid, decryptOffset, decryptLen);
 
@@ -238,7 +238,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
         
             if (IS_VVERBOSE)
             { 
-                VERBOSE("Writing PktID %d from stream 0x%04x\n",
+                VVERBOSE("Writing PktID %d from stream 0x%04x\n",
                         pPkt2->packetId, stream_pid);
                 pPkt2->dump();
             }
@@ -250,7 +250,7 @@ bool TiVoDecoderTsStream::addPkt(TiVoDecoderTsPacket *pPkt)
             }
             else
             {
-                VERBOSE("Wrote PktID %d from stream 0x%04x\n",
+                VVERBOSE("Wrote PktID %d from stream 0x%04x\n",
                         pPkt2->packetId, stream_pid);
             }
 


### PR DESCRIPTION
First, thank you for building this! Due to Comcast's TS/MP4 migration, I'm moving from tivodecode to this version, and had a problem with error output. Currently, in one mode, I use the stderr output to determine how complete the processing is. Verbose mode (-v) puts out a progress line per packet:
```
    703355: stream_no: e0, block_no: 4
    707658: stream_no: bd, block_no: 1
```
where the first block is the number of bytes processed, so I can easily compute how far processing is complete.

When I use -v with tivodecode-ng, it puts out a much longer stream for each packet in both TS and PS, resulting in multi-gigabyte files. So in this pull request, I demoted the Packet debug info to VVerbose and added the same reporting  `<FilePosition> : stream_id: xx block_no: dd` to the TS reporting. 

If you prefer the packet info to be in Verbose mode, I could instead create an independent Progress option that would just report the data above. Let me know.